### PR TITLE
Populate dataset fields (GSI-1573)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -85,12 +85,12 @@ components:
       required:
       - user_id
       - dataset_id
-      - dataset_title
-      - dac_alias
       - email
       - request_text
       - access_starts
       - access_ends
+      - dataset_title
+      - dac_alias
       - full_user_name
       - request_created
       title: AccessRequest
@@ -109,24 +109,10 @@ components:
           format: date-time
           title: Access Starts
           type: string
-        dac_alias:
-          description: The alias of the Data Access Committee.
-          title: Dac Alias
-          type: string
-        dataset_description:
-          anyOf:
-          - type: string
-          - type: 'null'
-          description: Description of the dataset
-          title: Dataset Description
         dataset_id:
           description: ID of the dataset for which access is requested
           pattern: ^[A-Z]{1,6}[0-9]{3,18}$
           title: Dataset Id
-          type: string
-        dataset_title:
-          description: Title of the dataset
-          title: Dataset Title
           type: string
         email:
           description: Contact e-mail address of the requester
@@ -150,8 +136,6 @@ components:
       required:
       - user_id
       - dataset_id
-      - dataset_title
-      - dac_alias
       - email
       - request_text
       - access_starts

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -258,6 +258,8 @@ paths:
           description: Access request was successfully created
         '403':
           description: Not authorized to create an access request.
+        '404':
+          description: Dataset not found
         '422':
           description: Validation error in submitted data.
       security:

--- a/src/ars/adapters/inbound/fastapi_/routes.py
+++ b/src/ars/adapters/inbound/fastapi_/routes.py
@@ -76,6 +76,8 @@ async def create_access_request(
         )
     except repository.AccessRequestAuthorizationError as exc:
         raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except repository.DatasetNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
     except repository.AccessRequestInvalidDuration as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except Exception as exc:

--- a/src/ars/adapters/inbound/fastapi_/routes.py
+++ b/src/ars/adapters/inbound/fastapi_/routes.py
@@ -60,6 +60,7 @@ async def health():
             "description": "Access request was successfully created",
         },
         403: {"description": "Not authorized to create an access request."},
+        404: {"description": "Dataset not found"},
         422: {"description": "Validation error in submitted data."},
     },
     status_code=201,

--- a/src/ars/core/models.py
+++ b/src/ars/core/models.py
@@ -70,13 +70,6 @@ class AccessRequestCreationData(BaseDto):
     dataset_id: Accession = Field(
         default=..., description="ID of the dataset for which access is requested"
     )
-    dataset_title: str = Field(default=..., description="Title of the dataset")
-    dataset_description: str | None = Field(
-        default=None, description="Description of the dataset"
-    )
-    dac_alias: str = Field(
-        default=..., description="The alias of the Data Access Committee."
-    )
     email: str = Field(
         default=..., description="Contact e-mail address of the requester"
     )
@@ -100,7 +93,13 @@ class AccessRequest(AccessRequestCreationData):
     """All data that describes an access request."""
 
     id: str = Field(default_factory=new_uuid4, description="ID of the access request")
-
+    dataset_title: str = Field(default=..., description="Title of the dataset")
+    dataset_description: str | None = Field(
+        default=None, description="Description of the dataset"
+    )
+    dac_alias: str = Field(
+        default=..., description="The alias of the Data Access Committee."
+    )
     full_user_name: str = Field(
         default=...,
         description="The requester's full name including academic title",

--- a/src/ars/core/repository.py
+++ b/src/ars/core/repository.py
@@ -95,6 +95,7 @@ class AccessRequestRepository(AccessRequestRepositoryPort):
         Raises:
         - `AccessRequestAuthorizationError` if the user is not authorized.
         - `AccessRequestInvalidDuration` error if the dates are invalid.
+        - `DatasetNotFoundError` if no dataset with given ID is found.
         """
         user_id = auth_context.id
         if not user_id or creation_data.user_id != user_id:
@@ -129,10 +130,16 @@ class AccessRequestRepository(AccessRequestRepositoryPort):
         if auth_context.title:
             full_user_name = auth_context.title + " " + full_user_name
 
+        # Retrieve the dataset by ID to populate title, description, and DAC alias
+        dataset = await self.get_dataset(creation_data.dataset_id)
+
         access_request = AccessRequest(
             **creation_data.model_dump(),
             full_user_name=full_user_name,
             request_created=request_created,
+            dataset_title=dataset.title,
+            dataset_description=dataset.description,
+            dac_alias=dataset.dac_alias,
         )
 
         await self._request_dao.insert(access_request)

--- a/src/ars/ports/inbound/repository.py
+++ b/src/ars/ports/inbound/repository.py
@@ -69,6 +69,7 @@ class AccessRequestRepositoryPort(ABC):
         Raises:
         - `AccessRequestAuthorizationError` if the user is not authorized.
         - `AccessRequestInvalidDuration` error if the dates are invalid.
+        - `DatasetNotFoundError` if no dataset with given ID is found.
         """
         ...
 

--- a/tests/test_outbox_pub.py
+++ b/tests/test_outbox_pub.py
@@ -34,9 +34,6 @@ CREATION_DATA = AccessRequestCreationData(
     user_id="id-of-john-doe@ghga.de",
     iva_id="some-iva",
     dataset_id="DS001",
-    dataset_title="Dataset1",
-    dataset_description="Some Description",
-    dac_alias="Some DAC",
     email="me@john-doe.name",
     request_text="Can I access some dataset?",
     access_starts=datetime(2025, 5, 6, 6, 45, 29, tzinfo=UTC),
@@ -46,6 +43,9 @@ CREATION_DATA = AccessRequestCreationData(
 access_request = AccessRequest(
     **CREATION_DATA.model_dump(),
     full_user_name="John Doe",
+    dataset_title="Dataset1",
+    dataset_description="Some Description",
+    dac_alias="Some DAC",
     request_created=now_as_utc(),
 )
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -301,8 +301,6 @@ async def test_can_create_request():
     creation_data = AccessRequestCreationData(
         user_id="id-of-john-doe@ghga.de",
         dataset_id="DS001",
-        dataset_title="Dataset1",
-        dac_alias="Some DAC",
         email="me@john-doe.name",
         request_text="Can I access some dataset?",
         access_starts=access_starts,
@@ -310,6 +308,15 @@ async def test_can_create_request():
     )
     creation_date = now_as_utc()
 
+    # Seed dataset so `repository.create` doesn't fail when it retrieves the dataset
+    await repository.register_dataset(
+        Dataset(
+            id="DS001",
+            title="A Great Dataset",
+            description="This is a good dataset",
+            dac_alias="Some DAC",
+        )
+    )
     request = await repository.create(creation_data, auth_context=auth_context_doe)
 
     assert request.user_id == "id-of-john-doe@ghga.de"
@@ -337,14 +344,21 @@ async def test_can_create_request_with_an_iva():
         user_id="id-of-john-doe@ghga.de",
         iva_id="some-iva_id",
         dataset_id="DS001",
-        dataset_title="Dataset1",
-        dac_alias="Some DAC",
         email="me@john-doe.name",
         request_text="Can I access some dataset?",
         access_starts=access_starts,
         access_ends=access_ends,
     )
 
+    # Seed dataset so `repository.create` doesn't fail when it retrieves the dataset
+    await repository.register_dataset(
+        Dataset(
+            id="DS001",
+            title="A Great Dataset",
+            description="This is a good dataset",
+            dac_alias="Some DAC",
+        )
+    )
     request = await repository.create(creation_data, auth_context=auth_context_doe)
 
     assert request.user_id == "id-of-john-doe@ghga.de"
@@ -361,8 +375,6 @@ async def test_cannot_create_request_for_somebody_else():
     creation_data = AccessRequestCreationData(
         user_id="id-of-john-foo@ghga.de",
         dataset_id="DS001",
-        dataset_title="Dataset1",
-        dac_alias="Some DAC",
         email="me@john-doe.name",
         request_text="Can I access some dataset?",
         access_starts=access_starts,
@@ -380,14 +392,21 @@ async def test_silently_correct_request_that_is_too_early():
     creation_data = AccessRequestCreationData(
         user_id="id-of-john-doe@ghga.de",
         dataset_id="DS001",
-        dataset_title="Dataset1",
-        dac_alias="Some DAC",
         email="me@john-doe.name",
         request_text="Can I access some dataset?",
         access_starts=access_starts,
         access_ends=access_ends,
     )
 
+    # Seed dataset so `repository.create` doesn't fail when it retrieves the dataset
+    await repository.register_dataset(
+        Dataset(
+            id="DS001",
+            title="A Great Dataset",
+            description="This is a good dataset",
+            dac_alias="Some DAC",
+        )
+    )
     request = await repository.create(creation_data, auth_context=auth_context_doe)
 
     assert 0 <= (request.request_created - creation_date).seconds < 5
@@ -404,8 +423,6 @@ async def test_cannot_create_request_too_much_in_advance():
     creation_data = AccessRequestCreationData(
         user_id="id-of-john-doe@ghga.de",
         dataset_id="DS001",
-        dataset_title="Dataset1",
-        dac_alias="Some DAC",
         email="me@john-doe.name",
         request_text="Can I access some dataset?",
         access_starts=access_starts,
@@ -427,8 +444,6 @@ async def test_cannot_create_request_too_short():
     creation_data = AccessRequestCreationData(
         user_id="id-of-john-doe@ghga.de",
         dataset_id="DS001",
-        dataset_title="Dataset1",
-        dac_alias="Some DAC",
         email="me@john-doe.name",
         request_text="Can I access some dataset?",
         access_starts=access_starts,
@@ -450,8 +465,6 @@ async def test_cannot_create_request_too_long():
     creation_data = AccessRequestCreationData(
         user_id="id-of-john-doe@ghga.de",
         dataset_id="DS001",
-        dataset_title="Dataset1",
-        dac_alias="Some DAC",
         email="me@john-doe.name",
         request_text="Can I access some dataset?",
         access_starts=access_starts,
@@ -464,6 +477,23 @@ async def test_cannot_create_request_too_long():
         await repository.create(creation_data, auth_context=auth_context_doe)
 
     assert access_request_dao.last_upsert is None
+
+
+async def test_cannot_create_request_nonexistent_dataset():
+    """Make sure we get a DatasetNotFoundError when the requested dataset ID doesn't exist."""
+    access_starts = now_as_utc()
+    access_ends = access_starts + ONE_YEAR
+    creation_data = AccessRequestCreationData(
+        user_id="id-of-john-doe@ghga.de",
+        dataset_id="DS404",
+        email="me@john-doe.name",
+        request_text="Can I access some dataset?",
+        access_starts=access_starts,
+        access_ends=access_ends,
+    )
+
+    with pytest.raises(repository.DatasetNotFoundError):
+        _ = await repository.create(creation_data, auth_context=auth_context_doe)
 
 
 async def test_can_get_all_requests_as_data_steward():


### PR DESCRIPTION
Changes `AccessRequestRepository.create()` so that it retrieves the `Dataset` in question from the DB, then uses it to populate the `dataset_title`, `dataset_description`, and `dac_alias` on the `AccessRequest` right before insertion. If the dataset doesn't exist, the error from `get_dataset` is allowed to bubble up (as opposed to translating it again) since it's already API-friendly.

Before this PR, the `AccessRequestionCreationData` model owned those three fields. However, that info isn't supplied by the front end. Thus, the fields were moved to the `AccessRequest` model.

The tests were updated:
- `test_api.py` got a new fixture which inserts a test dataset into the DB
- `test_repository.py` was updated so certain tests insert the test dataset right before calling the creation method.

A test was added to both the above modules that tests for access request creation when the requested dataset ID doesn't exist.

**NOTE**: The behavior for _updating_ datasets without existing IDs was _not_ included because there is a separate ticket (GSI-1572 and GSI-1614) which covers that.