### PR TITLE
Add v2 migration (GSI-1603)

### DIFF
--- a/.devcontainer/.dev_config.yaml
+++ b/.devcontainer/.dev_config.yaml
@@ -10,6 +10,8 @@ cors_allowed_headers: []
 
 mongo_dsn: "mongodb://mongodb:27017"
 db_name: "access-requests"
+migration_wait_sec: 10
+db_version_collection: arsDbVersions
 
 access_request_topic: access_request_events
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,67 @@ The service requires the following configuration parameters:
   ```
 
 
+- <a id="properties/db_version_collection"></a>**`db_version_collection`** *(string, required)*: The name of the collection containing DB version information for this service.
+
+
+  Examples:
+
+  ```json
+  "ifrsDbVersions"
+  ```
+
+
+- <a id="properties/migration_wait_sec"></a>**`migration_wait_sec`** *(integer, required)*: The number of seconds to wait before checking the DB version again.
+
+
+  Examples:
+
+  ```json
+  5
+  ```
+
+
+  ```json
+  30
+  ```
+
+
+  ```json
+  180
+  ```
+
+
+- <a id="properties/migration_max_wait_sec"></a>**`migration_max_wait_sec`**: The maximum number of seconds to wait for migrations to complete before raising an error. Default: `null`.
+
+  - **Any of**
+
+    - <a id="properties/migration_max_wait_sec/anyOf/0"></a>*integer*
+
+    - <a id="properties/migration_max_wait_sec/anyOf/1"></a>*null*
+
+
+  Examples:
+
+  ```json
+  null
+  ```
+
+
+  ```json
+  300
+  ```
+
+
+  ```json
+  600
+  ```
+
+
+  ```json
+  3600
+  ```
+
+
 - <a id="properties/log_level"></a>**`log_level`** *(string)*: The minimum log level to capture. Must be one of: `["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "TRACE"]`. Default: `"INFO"`.
 
 - <a id="properties/log_format"></a>**`log_format`**: If set, will replace JSON formatting with the specified string format. If not set, has no effect. In addition to the standard attributes, the following can also be specified: timestamp, service, instance, level, correlation_id, and details. Default: `null`.

--- a/config_schema.json
+++ b/config_schema.json
@@ -228,6 +228,43 @@
       ],
       "title": "Mongo Timeout"
     },
+    "db_version_collection": {
+      "description": "The name of the collection containing DB version information for this service",
+      "examples": [
+        "ifrsDbVersions"
+      ],
+      "title": "Db Version Collection",
+      "type": "string"
+    },
+    "migration_wait_sec": {
+      "description": "The number of seconds to wait before checking the DB version again",
+      "examples": [
+        5,
+        30,
+        180
+      ],
+      "title": "Migration Wait Sec",
+      "type": "integer"
+    },
+    "migration_max_wait_sec": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "The maximum number of seconds to wait for migrations to complete before raising an error.",
+      "examples": [
+        null,
+        300,
+        600,
+        3600
+      ],
+      "title": "Migration Max Wait Sec"
+    },
     "log_level": {
       "default": "INFO",
       "description": "The minimum log level to capture.",
@@ -440,6 +477,8 @@
     "kafka_servers",
     "mongo_dsn",
     "db_name",
+    "db_version_collection",
+    "migration_wait_sec",
     "auth_key"
   ],
   "title": "ModSettings",

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -22,6 +22,7 @@ dataset_change_topic: metadata_datasets
 dataset_deletion_type: dataset_deleted
 dataset_upsertion_type: dataset_created
 db_name: access-requests
+db_version_collection: arsDbVersions
 docs_url: /docs
 download_access_url: http://127.0.0.1:8080/download-access
 generate_correlation_id: true
@@ -41,6 +42,8 @@ kafka_ssl_password: ''
 log_format: null
 log_level: INFO
 log_traceback: true
+migration_max_wait_sec: null
+migration_wait_sec: 10
 mongo_dsn: '**********'
 mongo_timeout: null
 openapi_url: /openapi.json

--- a/src/ars/cli.py
+++ b/src/ars/cli.py
@@ -16,11 +16,12 @@
 """Entrypoint of the package"""
 
 import asyncio
+from typing import Annotated
 
 import typer
 from ghga_service_commons.utils.utc_dates import assert_tz_is_utc
 
-from ars.main import consume_events, run_rest_app
+from ars.main import consume_events, publish_events, run_rest_app
 
 cli = typer.Typer()
 
@@ -36,3 +37,13 @@ def sync_run_api():
 def sync_consume_events(run_forever: bool = True):
     """Run an event consumer listening to the configured topic."""
     asyncio.run(consume_events(run_forever=run_forever))
+
+
+@cli.command(name="publish-events")
+def sync_run_publish_events(
+    all: Annotated[
+        bool, typer.Option(help="Set to (re)publish all events regardless of status")
+    ] = False,
+):
+    """Publish pending events."""
+    asyncio.run(publish_events(all=all))

--- a/src/ars/config.py
+++ b/src/ars/config.py
@@ -19,6 +19,7 @@ from ghga_service_commons.api import ApiConfigBase
 from ghga_service_commons.auth.ghga import AuthConfig
 from hexkit.config import config_from_yaml
 from hexkit.log import LoggingConfig
+from hexkit.providers.mongodb.migrations import MigrationConfig
 from hexkit.providers.mongokafka import MongoKafkaConfig
 from pydantic import Field
 
@@ -35,6 +36,7 @@ class Config(
     ApiConfigBase,
     AuthConfig,
     LoggingConfig,
+    MigrationConfig,
     MongoKafkaConfig,
     EventSubTranslatorConfig,
     AccessRequestDaoConfig,

--- a/src/ars/main.py
+++ b/src/ars/main.py
@@ -19,13 +19,18 @@ from ghga_service_commons.api import run_server
 from hexkit.log import configure_logging
 
 from ars.config import Config
+from ars.migrations import run_db_migrations
 from ars.prepare import prepare_consumer, prepare_rest_app
+
+DB_VERSION = 2
 
 
 async def run_rest_app():
     """Run the HTTP REST API."""
     config = Config()  # type: ignore
     configure_logging(config=config)
+
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with prepare_rest_app(config=config) as app:
         await run_server(app=app, config=config)
@@ -35,6 +40,8 @@ async def consume_events(run_forever: bool = True) -> None:
     """Run an event consumer listening to the configured topic."""
     config = Config()  # type: ignore
     configure_logging(config=config)
+
+    await run_db_migrations(config=config, target_version=DB_VERSION)
 
     async with prepare_consumer(config=config) as consumer:
         await consumer.event_subscriber.run(forever=run_forever)

--- a/src/ars/migrations/__init__.py
+++ b/src/ars/migrations/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DB Migration logic"""
+
+from .definitions import V2Migration
+from .entry import run_db_migrations
+
+__all__ = ["V2Migration", "run_db_migrations"]

--- a/src/ars/migrations/definitions.py
+++ b/src/ars/migrations/definitions.py
@@ -1,0 +1,94 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Database migration logic for ARS"""
+
+from hexkit.correlation import new_correlation_id
+from hexkit.providers.mongodb.migrations import (
+    Document,
+    MigrationDefinition,
+    Reversible,
+)
+
+
+class V2Migration(MigrationDefinition, Reversible):
+    """Populate new AccessRequest fields with empty string or `None` as appropriate."""
+
+    version = 2
+
+    async def apply(self):
+        """Perform the migration and set the DB to version 2.
+
+        Changes for existing docs in "accessRequests" collection:
+        - Populate the required `dataset_title` and `dac_alias` fields with empty string
+        - Populate `__metadata__` field for outbox with "published=True" and made-up
+          correlation ID (since we don't know what was originally used).
+        - Add `dataset_description`, `ticket_id`, `internal_note`,
+          and `note_to_requester` with `None` because they are optional fields.
+        """
+
+        async def update_access_request_doc(doc: Document) -> Document:
+            """Populate the required fields for access request docs"""
+            doc["__metadata__"] = {
+                "correlation_id": new_correlation_id(),
+                "published": True,
+                "deleted": False,
+            }
+            doc["dataset_title"] = ""
+            doc["dac_alias"] = ""
+            for optional_field in [
+                "dataset_description",
+                "ticket_id",
+                "internal_note",
+                "note_to_requester",
+            ]:
+                doc[optional_field] = None
+            return doc
+
+        # Migrate the accessRequests collection and auto-finalize (replace old collection)
+        async with self.auto_finalize(coll_names="accessRequests", copy_indexes=False):
+            await self.migrate_docs_in_collection(
+                coll_name="accessRequests",
+                change_function=update_access_request_doc,
+            )
+
+    async def unapply(self):
+        """Reverse the migration so the DB will be back at version 1.
+
+        Changes for "accessRequests" collection:
+        - Remove `__metadata__` field
+        - Remove `dataset_title`, `dataset_description`, `dac_alias`, `ticket_id`,
+          `internal_note`, and `note_to_requester`
+        """
+
+        async def remove_access_request_fields(doc: Document) -> Document:
+            """Remove the aforementioned fields"""
+            for key in [
+                "__metadata__",
+                "dataset_title",
+                "dataset_description",
+                "dac_alias",
+                "ticket_id",
+                "internal_note",
+                "note_to_requester",
+            ]:
+                doc.pop(key)
+            return doc
+
+        async with self.auto_finalize(coll_names="accessRequests", copy_indexes=False):
+            await self.migrate_docs_in_collection(
+                coll_name="accessRequests",
+                change_function=remove_access_request_fields,
+            )

--- a/src/ars/migrations/entry.py
+++ b/src/ars/migrations/entry.py
@@ -1,0 +1,51 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing controller function for DB migrations"""
+
+from hexkit.providers.mongodb.migrations import (
+    MigrationConfig,
+    MigrationManager,
+    MigrationMap,
+)
+
+from ars.migrations.definitions import V2Migration
+
+MIGRATION_MAP = {2: V2Migration}
+
+
+async def run_db_migrations(
+    *,
+    config: MigrationConfig,
+    target_version: int,
+    migration_map: MigrationMap | None = None,
+):
+    """Run all migrations.
+
+    Args
+    - `config`: Config containing mongo_dsn string and DB versioning collection name
+    - `target_version`: Which version the db needs to be at for this version of the service
+    - `migration_map`: Mapping of version to migration definition. Defaults to `MIGRATION_MAP`.
+
+    `migration_map` can be specified for testing, but may be left unspecified for production.
+    """
+    migration_map = migration_map or MIGRATION_MAP
+
+    async with MigrationManager(
+        config=config,
+        target_version=target_version,
+        migration_map=MIGRATION_MAP,
+    ) as mm:
+        await mm.migrate_or_wait()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -27,7 +27,7 @@ from ars.migrations import V2Migration, run_db_migrations
 pytestmark = pytest.mark.asyncio()
 
 
-ACCESS_REQUESTS = [
+ACCESS_REQUESTS_V1 = [
     {
         "id": "request-id-1",
         "user_id": "id-of-john-doe@ghga.de",
@@ -93,7 +93,7 @@ async def test_v2_migration(mongodb: MongoDbFixture):
     access_request_collection = db["accessRequests"]
 
     # Insert some access requests and datasets
-    for access_request in ACCESS_REQUESTS:
+    for access_request in ACCESS_REQUESTS_V1:
         access_request_collection.insert_one(access_request)
 
     # Save this for later
@@ -105,7 +105,7 @@ async def test_v2_migration(mongodb: MongoDbFixture):
 
     # Verify V2 migration was applied correctly
     migrated_docs = access_request_collection.find().to_list()
-    assert len(migrated_docs) == len(ACCESS_REQUESTS)
+    assert len(migrated_docs) == len(ACCESS_REQUESTS_V1)
 
     for doc in migrated_docs:
         assert "__metadata__" in doc

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,133 @@
+# Copyright 2021 - 2025 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for migrations to ensure the output is what we expect."""
+
+from uuid import UUID
+
+import pytest
+from hexkit.providers.mongodb.migrations import MigrationConfig
+from hexkit.providers.mongodb.testutils import MongoDbFixture
+
+from ars.core.models import AccessRequestStatus
+from ars.migrations import V2Migration, run_db_migrations
+
+pytestmark = pytest.mark.asyncio()
+
+
+ACCESS_REQUESTS = [
+    {
+        "id": "request-id-1",
+        "user_id": "id-of-john-doe@ghga.de",
+        "dataset_id": "DS003",
+        "email": "me@john-doe.name",
+        "request_text": "Can I access yet another dataset using this IVA?",
+        "access_starts": "2025-03-28T14:43:13.375748Z",
+        "access_ends": "2026-03-28T22:59:59.999000Z",
+        "full_user_name": "Dr. John Doe",
+        "request_created": "2025-03-28T14:43:13.375748Z",
+        "status": AccessRequestStatus.PENDING,
+    },
+    {
+        "id": "request-id-2",
+        "user_id": "id-of-john-doe@ghga.de",
+        "dataset_id": "DS003",
+        "email": "me@john-doe.name",
+        "request_text": "Can I access yet another dataset using this IVA?",
+        "access_starts": "2025-03-28T14:43:13.375748Z",
+        "access_ends": "2026-03-28T22:59:59.999000Z",
+        "full_user_name": "Dr. John Doe",
+        "request_created": "2025-03-28T14:43:13.375748Z",
+        "status": AccessRequestStatus.PENDING,
+    },
+    {
+        "id": "request-id-3",
+        "user_id": "id-of-john-doe@ghga.de",
+        "dataset_id": "DS003",
+        "email": "me@john-doe.name",
+        "request_text": "Can I access yet another dataset using this IVA?",
+        "access_starts": "2025-03-28T14:43:13.375748Z",
+        "access_ends": "2026-03-28T22:59:59.999000Z",
+        "full_user_name": "Dr. John Doe",
+        "request_created": "2025-03-28T14:43:13.375748Z",
+        "status": AccessRequestStatus.PENDING,
+    },
+    {
+        "id": "request-id-4",
+        "user_id": "id-of-john-doe@ghga.de",
+        "dataset_id": "DS003",
+        "email": "me@john-doe.name",
+        "request_text": "Can I access yet another dataset using this IVA?",
+        "access_starts": "2025-03-28T14:43:13.375748Z",
+        "access_ends": "2026-03-28T22:59:59.999000Z",
+        "full_user_name": "Dr. John Doe",
+        "request_created": "2025-03-28T14:43:13.375748Z",
+        "status": AccessRequestStatus.PENDING,
+    },
+]
+
+
+async def test_v2_migration(mongodb: MongoDbFixture):
+    """Ensure the v2 migration populates the correct fields"""
+    migration_config = MigrationConfig(
+        mongo_dsn=mongodb.config.mongo_dsn,
+        db_name=mongodb.config.db_name,
+        db_version_collection="arsDbVersions",
+        migration_max_wait_sec=15,
+        migration_wait_sec=1,
+    )
+    db = mongodb.client[mongodb.config.db_name]
+
+    access_request_collection = db["accessRequests"]
+
+    # Insert some access requests and datasets
+    for access_request in ACCESS_REQUESTS:
+        access_request_collection.insert_one(access_request)
+
+    # Save this for later
+    pre_migration_docs = access_request_collection.find().to_list()
+
+    await run_db_migrations(
+        config=migration_config, target_version=2, migration_map={2: V2Migration}
+    )
+
+    # Verify V2 migration was applied correctly
+    migrated_docs = access_request_collection.find().to_list()
+    assert len(migrated_docs) == len(ACCESS_REQUESTS)
+
+    for doc in migrated_docs:
+        assert "__metadata__" in doc
+        assert doc["__metadata__"]["published"] == True
+        assert not doc["__metadata__"]["deleted"]
+        assert UUID(doc["__metadata__"]["correlation_id"])
+        assert doc["dataset_title"] == ""
+        assert doc["dac_alias"] == ""
+        for field in [
+            "dataset_description",
+            "ticket_id",
+            "internal_note",
+            "note_to_requester",
+        ]:
+            assert field in doc
+            assert doc[field] == None
+
+    # Reverse the V2 migration
+    await run_db_migrations(
+        config=migration_config, target_version=1, migration_map={2: V2Migration}
+    )
+
+    # Make sure contents now match beginning
+    reverted_docs = access_request_collection.find().to_list()
+    assert reverted_docs == pre_migration_docs


### PR DESCRIPTION
Adds the v2 migration. This migration adds the following information to every existing `AccessRequest` in the ARS database:
- `__metadata__`: `{"published": True, "deleted": False, "correlation_id": <random new CID>}`
- `dataset_title`: `""`
- `dac_alias`: `""`
- `dataset_description`: `None`
- `ticket_id`: `None`
- `internal_note`: `None`
- `note_to_requester`: `None`

The reverse migration will remove the aforementioned fields, which should all be present because they were all added by the migration, and new data will automatically have the fields as well.

Also included in this PR is the standard CLI command to republish outbox events.

This PR does not touch the project version number since it is meant to be included with version `4.0.0`.